### PR TITLE
Fixed to resolve errors in py.test caused by missing __init__.py

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import absolute_import

--- a/tests/python/base/test_views.py
+++ b/tests/python/base/test_views.py
@@ -3,7 +3,7 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from python.accounts.test_models import UserFactory
+from tests.python.accounts.test_models import UserFactory
 
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')


### PR DESCRIPTION
I received errors using py.test from the base path.
The errors were resolved by adding __init__.py to the tests dir, and also fixing the import statement on one of the test files itself.

