### PR TITLE
Update views.py

### DIFF
--- a/src/base/views.py
+++ b/src/base/views.py
@@ -23,7 +23,8 @@ class ProtectedDataView(GenericAPIView):
     """Return protected data  main page."""
 
     authentication_classes = (JSONWebTokenAuthentication,)
-
+    permission_classes = (IsAuthenticated,)
+    
     def get(self, request):
         """Process GET request and return protected data."""
 

--- a/src/static/containers/Login/index.js
+++ b/src/static/containers/Login/index.js
@@ -3,10 +3,13 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as actionCreators from '../../actions/auth';
 import classNames from 'classnames';
+import { push } from 'react-router-redux';
 
 class LoginView extends React.Component {
 
     static propTypes = {
+        dispatch: React.PropTypes.func.isRequired,
+        isAuthenticated: React.PropTypes.bool.isRequired,
         isAuthenticating: React.PropTypes.bool.isRequired,
         statusText: React.PropTypes.string,
         actions: React.PropTypes.object.isRequired,
@@ -22,6 +25,12 @@ class LoginView extends React.Component {
             password: '',
             redirectTo: redirectRoute
         };
+    }
+
+    componentWillMount() {
+        if (this.props.isAuthenticated) {
+            this.props.dispatch(push('/'));
+        }
     }
 
     login = (e) => {
@@ -112,6 +121,7 @@ class LoginView extends React.Component {
 
 const mapStateToProps = (state) => {
     return {
+        isAuthenticated: state.auth.isAuthenticated,
         isAuthenticating: state.auth.isAuthenticating,
         statusText: state.auth.statusText
     };
@@ -119,6 +129,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
     return {
+        dispatch,
         actions: bindActionCreators(actionCreators, dispatch)
     };
 };


### PR DESCRIPTION
1) Currently, the /getdata/ endpoint does not require any authentication. To reproduce, deploy the project locally and run:

```
curl http://localhost:8000/api/v1/getdata/
```

That works. It shouldn't. It should require the JWT since it's returning protected data.

2) The user should be redirected to root if they are already logged in. I think it should be included to round out the bare minimum logic needed for auth.